### PR TITLE
fix(texlive): use correct bin\windows path

### DIFF
--- a/bucket/texlive.json
+++ b/bucket/texlive.json
@@ -20,9 +20,6 @@
             "Write-Output 'Downloading and installing TeX Live packages...'",
             "Invoke-ExternalCommand -Path \"$dir\\installer\\install-tl-windows.bat\" -ArgumentList $installArgs",
             "Remove-Item \"$dir\\installer\" -Recurse -Force | Out-Null",
-            "if (!(Test-Path \"$dir\\bin\\win64\")) {",
-            "    New-Item -Type Directory -Path \"$dir\\bin\\win64\" | Out-Null",
-            "}",
             "# Unset install envs",
             "$env:TEXLIVE_INSTALL_PAPER=''",
             "$env:TEXLIVE_INSTALL_PREFIX=''",
@@ -32,8 +29,7 @@
         ]
     },
     "env_add_path": [
-        "bin\\win64",
-        "bin\\win32"
+        "bin\\windows"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
## Summary

- Since TeX Live 2023, Windows binaries are installed to `bin/windows` instead of `bin/win32` ([release notes](https://www.preining.info/blog/2023/03/tex-live-2023-released/)). The `bin/win64` directory was never used by TeX Live.
- The current manifest adds `bin\win64` (empty) and `bin\win32` (nonexistent) to PATH, so none of the TeX Live binaries are found after installation.
- This PR changes `env_add_path` to `bin\windows` and removes the installer script line that created the empty `bin\win64` directory.

## Test plan

- [ ] `scoop install texlive` completes successfully
- [ ] `pdflatex --version` works without manually fixing PATH
- [ ] `ls ~/scoop/apps/texlive/current/bin/windows/` contains the binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)